### PR TITLE
update Tiled client header to direct to acquisition cluster

### DIFF
--- a/startup/02-tiled_writer.py
+++ b/startup/02-tiled_writer.py
@@ -185,6 +185,7 @@ class RunNormalizerHXN(RunNormalizer):
 
 api_key = os.environ.get("TILED_BLUESKY_WRITING_API_KEY_HXN")
 tiled_writing_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)['hxn']['migration']
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 RE.md["tiled_access_tags"] = ["hxn_beamline"]
 
 tw = TiledWriter(client = tiled_writing_client,


### PR DESCRIPTION
Add item that directs use of Tiled acquisition cluster to be used while acquiring data. Tiled clients from Prefect workflows, Jupyter notebooks, and other sources will be isolated from the acquisition cluster, ensuring data acquisition is not negatively affected by non-acquisition Tiled requests.