### PR TITLE
fixed NameErrors on bsui exit

### DIFF
--- a/startup/10-optics.py
+++ b/startup/10-optics.py
@@ -30,17 +30,24 @@ class PseudoEnergyCal(PseudoPositioner, NamedDevice):
         self.mono_angle.subscribe(self.parameter_updated)
         # self.energy.subscribe(self.parameter_updated)
 
+        # The subscribe callback expects methods to exist during
+        # session teardown that get removed, which causes errors
+        # on exiting bsui. Solution is to bind those methods beforehand
+        self._sin = math.sin
+        self._pi = math.pi
+        self._asin = math.asin
+
     def parameter_updated(self, value=None, **kwargs):
         self._update_position()
 
     @pseudo_position_argument
     def forward(self, position):
-        angle = math.asin((12.39842)/(2 * 3.1355893 * position.energy)) * (180/math.pi)
+        angle = self._asin((12.39842)/(2 * 3.1355893 * position.energy)) * (180/self._pi)
         return self.RealPosition(mono_angle=angle)
 
     @real_position_argument
     def inverse(self, position):
-        energy_kev = 12.39842 / (2. * 3.1355893 * math.sin(position.mono_angle*math.pi/180.))
+        energy_kev = 12.39842 / (2. * 3.1355893 * self._sin(position.mono_angle*self._pi/180.))
         return self.PseudoPosition(energy=energy_kev)
 
 

--- a/startup/12-endstation.py
+++ b/startup/12-endstation.py
@@ -166,13 +166,27 @@ class DetectorStation(PseudoPositioner):
     delta = Cpt(PseudoSingle)
     r = Cpt(PseudoSingle)
 
+    def __init__(self, prefix, **kwargs):
+        super().__init__(prefix, **kwargs)
+
+        # The subscribe callback expects methods to exist during
+        # session teardown that get removed, which causes errors
+        # on exiting bsui. Solution is to bind those methods beforehand
+        self._deg2rad = np.deg2rad
+        self._sin = np.sin
+        self._pi = np.pi
+        self._nan = np.nan
+        self._arctan = np.arctan
+        self._cos = np.cos
+        self._rad2deg = np.rad2deg
+
     @pseudo_position_argument
     def forward(self, position):
-        gamma = np.deg2rad(position.gamma)
-        delta = np.deg2rad(position.delta)
+        gamma = self._deg2rad(position.gamma)
+        delta = self._deg2rad(position.delta)
         r = position.r
 
-        beta = np.deg2rad(89.337)
+        beta = self._deg2rad(89.337)
 
         diff_z = self.z.position
 
@@ -188,8 +202,8 @@ class DetectorStation(PseudoPositioner):
         # d = 395.2
 
 
-        x_yaw = np.sin(gamma) * z_yaw / np.sin(beta + gamma)
-        R_yaw = np.sin(beta) * z_yaw / np.sin(beta + gamma)
+        x_yaw = self._sin(gamma) * z_yaw / self._sin(beta + gamma)
+        R_yaw = self._sin(beta) * z_yaw / self._sin(beta + gamma)
         R1 = R_yaw - (z_yaw - z1)
         R2 = R_yaw - (z_yaw - z2)
         y1 = np.tan(delta) * R1
@@ -222,35 +236,35 @@ class DetectorStation(PseudoPositioner):
     @real_position_argument
     def inverse(self, position):
         diff_z = position.z
-        diff_yaw = np.deg2rad(position.yaw)
+        diff_yaw = self._deg2rad(position.yaw)
         diff_cz = position.cz
         diff_x = position.x
         diff_y1 = position.y1
         diff_y2 = position.y2
 
         gamma = diff_yaw
-        beta = 89.337 * np.pi / 180
+        beta = 89.337 * self._pi / 180
         z_yaw = 574.668 + 581.20 + diff_z
         z1 = 574.668 + 395.2 + diff_z
         z2 = z1 + 380
         d = 395.2
 
-        x_yaw = np.sin(gamma) * z_yaw / np.sin(beta + gamma)
-        R_yaw = np.sin(beta) * z_yaw / np.sin(beta + gamma)
+        x_yaw = self._sin(gamma) * z_yaw / self._sin(beta + gamma)
+        R_yaw = self._sin(beta) * z_yaw / self._sin(beta + gamma)
         R1 = R_yaw - (z_yaw - z1)
         R2 = R_yaw - (z_yaw - z2)
 
 
         if abs(x_yaw + diff_x) > 3:
-            gamma = delta = r = np.nan
+            gamma = delta = r = self._nan
         elif abs(diff_y1 / R1 - diff_y2 / R2) > 0.01:
-            gamma = delta = r = np.nan
+            gamma = delta = r = self._nan
         else:
-            delta = np.arctan(diff_y1 / R1)
-            r = R1 / np.cos(delta) - d + diff_cz
+            delta = self._arctan(diff_y1 / R1)
+            r = R1 / self._cos(delta) - d + diff_cz
 
-        return self.PseudoPosition(gamma=np.rad2deg(gamma),
-                                   delta=np.rad2deg(delta),
+        return self.PseudoPosition(gamma=self._rad2deg(gamma),
+                                   delta=self._rad2deg(delta),
                                    r=r)
 
 

--- a/startup/13-mll.py
+++ b/startup/13-mll.py
@@ -183,18 +183,25 @@ class PseudoAngleCorrection(PseudoPositioner, NamedDevice):
         # if theta changes, update the pseudo position
         self.theta.subscribe(self.parameter_updated)
 
+        # The subscribe callback expects methods to exist during
+        # session teardown that get removed, which causes errors
+        # on exiting bsui. Solution is to bind those methods beforehand
+        self._radians = math.radians
+        self._cos = math.cos
+        self._sin = math.sin
+
     def parameter_updated(self, value=None, **kwargs):
         self._update_position()
 
     @property
     def radian_theta(self):
-        return math.radians(self.theta.get())
+        return self._radians(self.theta.get())
 
     @pseudo_position_argument
     def forward(self, position):
         theta = self.radian_theta
-        c = math.cos(theta)
-        s = math.sin(theta)
+        c = self._cos(theta)
+        s = self._sin(theta)
 
         x = c * position.px + s * position.pz
         z = -s * position.px + c * position.pz
@@ -203,8 +210,8 @@ class PseudoAngleCorrection(PseudoPositioner, NamedDevice):
     @real_position_argument
     def inverse(self, position):
         theta = self.radian_theta
-        c = math.cos(theta)
-        s = math.sin(theta)
+        c = self._cos(theta)
+        s = self._sin(theta)
         x = c * position.x - s * position.z
         z = s * position.x + c * position.z
         return self.PseudoPosition(px=x, pz=z)

--- a/startup/15-zp.py
+++ b/startup/15-zp.py
@@ -142,18 +142,25 @@ class FineSampleLabX(PseudoPositioner, NamedDevice):
         # if theta changes, update the pseudo position
         self.theta0.subscribe(self.parameter_updated)
 
+        # The subscribe callback expects methods to exist during
+        # session teardown that get removed, which causes errors
+        # on exiting bsui. Solution is to bind those methods beforehand
+        self._radians = math.radians
+        self._cos = math.cos
+        self._sin = math.sin
+
     def parameter_updated(self, value=None, **kwargs):
         self._update_position()
 
     @property
     def radian_theta(self):
-        return math.radians(self.zpsth.position + self.theta0.get())
+        return self._radians(self.zpsth.position + self.theta0.get())
 
     @pseudo_position_argument
     def forward(self, position):
         theta = self.radian_theta
-        c = math.cos(theta)
-        s = math.sin(theta)
+        c = self._cos(theta)
+        s = self._sin(theta)
 
         x = c * position.zpssx_lab + s * position.zpssz_lab
         z = -s * position.zpssx_lab + c * position.zpssz_lab
@@ -162,8 +169,8 @@ class FineSampleLabX(PseudoPositioner, NamedDevice):
     @real_position_argument
     def inverse(self, position):
         theta = self.radian_theta
-        c = math.cos(theta)
-        s = math.sin(theta)
+        c = self._cos(theta)
+        s = self._sin(theta)
         x = c * position.zpssx - s * position.zpssz
         z = s * position.zpssx + c * position.zpssz
         return self.PseudoPosition(zpssx_lab=x, zpssz_lab=z)


### PR DESCRIPTION
`NameError` was caused by an object subscription that ran a method every time some parameter was changed. During teardown of bsui, as objects are deleted from memory, the subscribed object changes value (it is deleted), which causes the subscribed method to run. If imported modules have also been deleted before this happens (such as `math` or `numpy`), the method throws an error saying it cannot find the module. The solution is to bind those methods to callables on the object itself, so they are not deleted during teardown before the method is called.

The errors are intermittent though - objects are not removed from memory in the same order on every exit. So I may not have gotten all the offending methods. You can follow this pattern in the future if any more pop up.